### PR TITLE
Clean up dependency lists

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ authors = [
 ]
 dependencies = [
     "PySide6==6.6.1",
+    "PySide6-Addons==6.6.1",
     "peewee==3.17.0",
-    "PyInstaller==6.3.0",
-    "typing-extensions==4.8.0"
+    "PyInstaller==6.3.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,3 @@ black==23.11.0
 # Типы для mypy
 types-setuptools==68.2.0.2
 
-# Дополнительные утилиты
-typing-extensions==4.8.0 


### PR DESCRIPTION
## Summary
- add missing `PySide6-Addons` dependency
- remove unused `typing-extensions`

## Testing
- `python -m pytest -q tests/test_database_simple.py` *(fails: ModuleNotFoundError: No module named 'peewee')*

------
https://chatgpt.com/codex/tasks/task_e_6849a95ba4508328b13e50ab12c856f5