### PR TITLE
Clean up dependency lists

### DIFF
--- a/build.py
+++ b/build.py
@@ -10,6 +10,7 @@ import zipfile
 from datetime import datetime
 import glob
 import platform
+import xml.etree.ElementTree as ET
 
 def check_requirements():
     """Проверка всех требований перед сборкой"""
@@ -58,13 +59,52 @@ def check_requirements():
         errors.append("❌ Файл src/full_app.py не найден")
     else:
         print("✅ Исходный файл найден")
+
+    # Проверяем ресурсы
+    if not check_resources():
+        errors.append("❌ Проблемы с ресурсами")
     
     if errors:
         print("\n⛔ Обнаружены проблемы:")
         for error in errors:
             print(error)
         return False
-    
+
+    return True
+
+def check_resources():
+    """Проверить наличие всех ресурсов"""
+    print("\n🔍 Проверка ресурсов (иконок и стилей)...")
+
+    qrc_path = os.path.join("resources", "styles.qrc")
+    compiled_rc = os.path.join("src", "resources_rc.py")
+
+    if not os.path.exists(qrc_path):
+        print(f"❌ Файл ресурсов не найден: {qrc_path}")
+        return False
+
+    missing = []
+    tree = ET.parse(qrc_path)
+    root = tree.getroot()
+    for file_elem in root.findall(".//file"):
+        rel_path = os.path.join("resources", file_elem.text)
+        if os.path.exists(rel_path):
+            print(f"✅ {rel_path}")
+        else:
+            missing.append(rel_path)
+
+    if missing:
+        print("\n⚠️ Отсутствуют ресурсы:")
+        for path in missing:
+            print(f" - {path}")
+        return False
+
+    if not os.path.exists(compiled_rc):
+        print(f"❌ Не найден скомпилированный файл ресурсов: {compiled_rc}")
+        print("   Запустите scripts/compile_resources.py и повторите сборку")
+        return False
+
+    print("✅ Все ресурсы на месте")
     return True
 
 def clean_build_artifacts():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ authors = [
 ]
 dependencies = [
     "PySide6==6.6.1",
+    "PySide6-Addons==6.6.1",
     "peewee==3.17.0",
-    "PyInstaller==6.3.0",
-    "typing-extensions==4.8.0"
+    "PyInstaller==6.3.0"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,3 @@ black==23.11.0
 # Типы для mypy
 types-setuptools==68.2.0.2
 
-# Дополнительные утилиты
-typing-extensions==4.8.0 


### PR DESCRIPTION
## Summary
- add missing `PySide6-Addons` dependency
- remove unused `typing-extensions`
- add resource check step to build script

## Testing
- `python -m pytest -q tests/test_database_simple.py` *(fails: ModuleNotFoundError: No module named 'peewee')*


------
https://chatgpt.com/codex/tasks/task_e_6849a95ba4508328b13e50ab12c856f5